### PR TITLE
Restrict slf4j-simple to the test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
         </dependency>
         <!-- The following dependency is generated using webjars.org. If 
              it does not resolve, go to https://www.webjars.org and deploy it as "Bower GitHub"


### PR DESCRIPTION
An add-on shouldn't define a logging implementation for the using application

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/component-starter-flow/19)
<!-- Reviewable:end -->
